### PR TITLE
libxkbcommon: toolchain newer than target, prevent symbol xkb_keymap_mod_get_mask not found

### DIFF
--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -1750,7 +1750,7 @@ static void keyboard_handle_keymap(void *data, struct wl_keyboard *keyboard,
     seat->keyboard.sdl_keymap = NULL;
     seat->keyboard.xkb.num_layouts = 0;
 
-#if SDL_XKBCOMMON_CHECK_VERSION(1, 10, 0)
+#if SDL_XKBCOMMON_CHECK_VERSION(1, 10, 0) && !defined(__WEBOS__)
     seat->keyboard.xkb.shift_mask = WAYLAND_xkb_keymap_mod_get_mask(seat->keyboard.xkb.keymap, XKB_MOD_NAME_SHIFT);
     seat->keyboard.xkb.ctrl_mask = WAYLAND_xkb_keymap_mod_get_mask(seat->keyboard.xkb.keymap, XKB_MOD_NAME_CTRL);
     seat->keyboard.xkb.alt_mask = WAYLAND_xkb_keymap_mod_get_mask(seat->keyboard.xkb.keymap, XKB_VMOD_NAME_ALT);

--- a/src/video/wayland/SDL_waylandsym.h
+++ b/src/video/wayland/SDL_waylandsym.h
@@ -168,7 +168,7 @@ SDL_WAYLAND_SYM(const char *, xkb_keymap_layout_get_name, (struct xkb_keymap *, 
 SDL_WAYLAND_SYM_OPT(size_t, xkb_keymap_key_get_mods_for_level, (struct xkb_keymap *, xkb_keycode_t, xkb_layout_index_t, xkb_level_index_t, xkb_mod_mask_t *, size_t) )
 SDL_WAYLAND_SYM(xkb_level_index_t, xkb_state_key_get_level, (struct xkb_state *, xkb_keycode_t, xkb_layout_index_t) )
 
-#if SDL_XKBCOMMON_CHECK_VERSION(1, 10, 0)
+#if SDL_XKBCOMMON_CHECK_VERSION(1, 10, 0) && !defined(__WEBOS__)
 SDL_WAYLAND_SYM(xkb_mod_mask_t, xkb_keymap_mod_get_mask, (struct xkb_keymap *, const char *))
 #endif
 


### PR DESCRIPTION
## Description
When building with a newer toolchain (which has an updated libxkbcommon), the compiler will use xkb_keymap_mod_get_mask.

This is not found on the target TV, so it will crash.

## Existing Issue(s)
