### PR TITLE
webOS: reimplement check SDL_WEBOS_BROKEN_ABI as libwayland-webos-client does not exist in 64-bit

### DIFF
--- a/src/video/wayland/SDL_waylanddyn.c
+++ b/src/video/wayland/SDL_waylanddyn.c
@@ -122,7 +122,7 @@ void SDL_WAYLAND_UnloadSymbols(void)
                     waylandlibs[i].lib = NULL;
                 }
             }
-#ifdef SDL_VIDEO_DRIVER_WAYLAND_WEBOS
+#if defined (SDL_VIDEO_DRIVER_WAYLAND_WEBOS) && defined (SDL_WEBOS_BROKEN_ABI)
             WaylandWebOS_AbiFixFini();
 #endif
 #endif
@@ -172,7 +172,7 @@ int SDL_WAYLAND_LoadSymbols(void)
         if(!WAYLAND_wl_proxy_marshal_constructor_versioned) {
             WAYLAND_wl_proxy_marshal_constructor_versioned = FALLBACK_wl_proxy_marshal_constructor_versioned;
         }
-#ifdef SDL_VIDEO_DRIVER_WAYLAND_WEBOS
+#if defined (SDL_VIDEO_DRIVER_WAYLAND_WEBOS) && defined (SDL_WEBOS_BROKEN_ABI)
         if (WaylandWebOS_AbiFixInit() != 0) {
             rc = 0;
         }

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -972,11 +972,15 @@ static void display_handle_global(void *data, struct wl_registry *registry, uint
     } else if (SDL_strcmp(interface, "wl_webos_input_manager") == 0) {
         // Danger! Requests of wl_webos_input_manager has completely broken ABI.
         // NEVER use this interface directly.
+#ifdef SDL_WEBOS_BROKEN_ABI
         const struct wl_interface *iface = WaylandWebOS_AbiFixGetInterface(interface);
         if (iface) {
             d->webos_input_manager = wl_registry_bind(registry, id, iface, 1);
             wl_webos_input_manager_add_listener(d->webos_input_manager, &webos_input_manager_listener, d);
         }
+#else
+        d->webos_input_manager = wl_registry_bind(registry, id, &wl_webos_input_manager_interface, 1);
+#endif
     } else if (SDL_strcmp(interface, "wl_starfish_pointer") == 0) {
         SDL_VideoDevice *device = SDL_GetVideoDevice();
         d->starfish_pointer = wl_registry_bind(registry, id, &wl_starfish_pointer_interface, 1);


### PR DESCRIPTION
## Description

SDL_WEBOS_BROKEN_ABI should be checked as libwayland-webos-client.so.1 does not exist in 64-bit libs.

Same fix was added in https://github.com/webosbrew/SDL-webOS/pull/7.

## Existing Issue(s)

